### PR TITLE
feat(builds): add SVM_TARGET_PLATFORM to override the svm platform to use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod error;
 pub use error::SolcVmError;
 
 mod platform;
-pub use platform::platform;
+pub use platform::{platform, Platform};
 
 mod releases;
 pub use releases::{all_releases, Releases};

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,8 +1,9 @@
 use std::fmt::Formatter;
+use std::str::FromStr;
 use std::{env, fmt};
 
 /// Types of supported platforms.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum Platform {
     LinuxAmd64,
     LinuxAarch64,
@@ -23,6 +24,21 @@ impl fmt::Display for Platform {
             Platform::Unsupported => "Unsupported-platform",
         };
         f.write_str(s)
+    }
+}
+
+impl FromStr for Platform {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "linux-amd64" => Ok(Platform::LinuxAmd64),
+            "linux-aarch64" => Ok(Platform::LinuxAarch64),
+            "macosx-amd64" => Ok(Platform::MacOsAmd64),
+            "macosx-aarch64" => Ok(Platform::MacOsAarch64),
+            "windows-amd64" => Ok(Platform::WindowsAmd64),
+            s => Err(format!("unsupported platform {}", s)),
+        }
     }
 }
 

--- a/svm-builds/build.rs
+++ b/svm-builds/build.rs
@@ -1,6 +1,28 @@
 use semver::Version;
 use svm::Releases;
 
+/// The string describing the [svm::Platform] to build for
+///
+/// Supported values are:
+///
+/// - "linux-amd64"
+/// - "linux-aarch64"
+/// - "macosx-amd64"
+/// - "macosx-aarch64"
+/// - "windows-amd64"
+pub const SVM_TARGET_PLATFORM: &str = "SVM_TARGET_PLATFORM";
+
+/// Returns the platform to generate the constants for
+///
+/// if the `SVM_TARGET_PLATFORM` var is set, this will return the matching [svm::Platform], otherwise the native platform will be used [svm::platform()]
+fn get_platform() -> svm::Platform {
+    if let Ok(s) = std::env::var(SVM_TARGET_PLATFORM) {
+        s.parse().unwrap()
+    } else {
+        svm::platform()
+    }
+}
+
 fn version_const_name(version: &Version) -> String {
     format!(
         "SOLC_VERSION_{}_{}_{}",
@@ -9,7 +31,11 @@ fn version_const_name(version: &Version) -> String {
 }
 
 /// Adds build info related constants
-fn add_build_info_constants(writer: &mut build_const::ConstValueWriter, releases: &Releases) {
+fn add_build_info_constants(
+    writer: &mut build_const::ConstValueWriter,
+    releases: &Releases,
+    platform: svm::Platform,
+) {
     let mut version_idents = Vec::with_capacity(releases.builds.len());
     let mut checksum_match_arms = Vec::with_capacity(releases.builds.len());
 
@@ -45,7 +71,7 @@ fn add_build_info_constants(writer: &mut build_const::ConstValueWriter, releases
 pub static ALL_SOLC_VERSIONS : [semver::Version; {}] = [
     {}  ];
     "#,
-        svm::platform(),
+        platform,
         version_idents.len(),
         version_idents.join(",\n")
     );
@@ -69,28 +95,29 @@ pub fn get_checksum(version: &semver::Version) -> Option<Vec<u8>> {{
 }
 
 /// checks the current platform and adds it as constant
-fn add_platform_const(writer: &mut build_const::ConstValueWriter) {
+fn add_platform_const(writer: &mut build_const::ConstValueWriter, platform: svm::Platform) {
     writer.add_raw(&format!(
         r#"
 /// The `svm::Platform` all constants were built for
 pub const TARGET_PLATFORM: &str = "{}";
 "#,
-        svm::platform()
+        platform
     ));
 }
 
 fn main() {
-    let releases = svm::blocking_all_releases(svm::platform()).expect("Failed to fetch releases");
+    let platform = get_platform();
+    let releases = svm::blocking_all_releases(platform).expect("Failed to fetch releases");
 
     let mut writer = build_const::ConstWriter::for_build("builds")
         .unwrap()
         .finish_dependencies();
 
     // add the platform as constant
-    add_platform_const(&mut writer);
+    add_platform_const(&mut writer, platform);
 
     // add all solc version info
-    add_build_info_constants(&mut writer, &releases);
+    add_build_info_constants(&mut writer, &releases, platform);
 
     // add the whole release string
     let release_json = serde_json::to_string(&releases).unwrap();


### PR DESCRIPTION
if we cross compile for a different target we still end up detecting the svm Platform based on the CPU that executes the build script

this adds support to override the platform via `SVM_TARGET_PLATFORM` env var