### PR TITLE
Allow to override the releases list manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,7 @@ dependencies = [
  "build_const",
  "hex",
  "semver",
+ "serde",
  "serde_json",
  "svm-rs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,6 @@ dependencies = [
  "build_const",
  "hex",
  "semver",
- "serde",
  "serde_json",
  "svm-rs",
 ]

--- a/crates/svm-builds/build.rs
+++ b/crates/svm-builds/build.rs
@@ -124,7 +124,7 @@ fn generate() {
 
     let releases: Releases = if let Ok(file_path) = std::env::var(SVM_RELEASES_LIST_JSON) {
         let file = File::open(file_path)
-            .expect("SVM_RELEASES_LIST_JSON defined, but cannot read the file referenced");
+            .expect(&format!("{:?} defined, but cannot read the file referenced", SVM_RELEASES_LIST_JSON));
 
         serde_json::from_reader(file)
             .expect("Fialed to parse the JSON from SVM_RELEASES_LIST_JSON file")

--- a/crates/svm-builds/build.rs
+++ b/crates/svm-builds/build.rs
@@ -123,15 +123,19 @@ fn generate() {
     let platform = get_platform();
 
     let releases: Releases = if let Ok(file_path) = std::env::var(SVM_RELEASES_LIST_JSON) {
-        let file = File::open(file_path).unwrap_or_else(|_| panic!(
-            "{:?} defined, but cannot read the file referenced",
-            SVM_RELEASES_LIST_JSON
-        ));
+        let file = File::open(file_path).unwrap_or_else(|_| {
+            panic!(
+                "{:?} defined, but cannot read the file referenced",
+                SVM_RELEASES_LIST_JSON
+            )
+        });
 
-        serde_json::from_reader(file).unwrap_or_else(|_| panic!(
-            "Failed to parse the JSON from {:?} file",
-            SVM_RELEASES_LIST_JSON
-        ))
+        serde_json::from_reader(file).unwrap_or_else(|_| {
+            panic!(
+                "Failed to parse the JSON from {:?} file",
+                SVM_RELEASES_LIST_JSON
+            )
+        })
     } else {
         svm::blocking_all_releases(platform).expect("Failed to fetch releases")
     };

--- a/crates/svm-builds/build.rs
+++ b/crates/svm-builds/build.rs
@@ -123,11 +123,15 @@ fn generate() {
     let platform = get_platform();
 
     let releases: Releases = if let Ok(file_path) = std::env::var(SVM_RELEASES_LIST_JSON) {
-        let file = File::open(file_path)
-            .expect(&format!("{:?} defined, but cannot read the file referenced", SVM_RELEASES_LIST_JSON));
+        let file = File::open(file_path).unwrap_or_else(|_| panic!(
+            "{:?} defined, but cannot read the file referenced",
+            SVM_RELEASES_LIST_JSON
+        ));
 
-        serde_json::from_reader(file)
-            .expect(&format!("Failed to parse the JSON from {:?} file", SVM_RELEASES_LIST_JSON))
+        serde_json::from_reader(file).unwrap_or_else(|_| panic!(
+            "Failed to parse the JSON from {:?} file",
+            SVM_RELEASES_LIST_JSON
+        ))
     } else {
         svm::blocking_all_releases(platform).expect("Failed to fetch releases")
     };

--- a/crates/svm-builds/build.rs
+++ b/crates/svm-builds/build.rs
@@ -127,7 +127,7 @@ fn generate() {
             .expect(&format!("{:?} defined, but cannot read the file referenced", SVM_RELEASES_LIST_JSON));
 
         serde_json::from_reader(file)
-            .expect("Fialed to parse the JSON from SVM_RELEASES_LIST_JSON file")
+            .expect(&format!("Failed to parse the JSON from {:?} file", SVM_RELEASES_LIST_JSON))
     } else {
         svm::blocking_all_releases(platform).expect("Failed to fetch releases")
     };


### PR DESCRIPTION
Check the `SVM_RELEASES_LIST_JSON` env variable first, and if it's defined then try loading the releases list from a local file.

Fixes #79 