### PR TITLE
Fix race condition between instances of svm in setting up the SVM directory

### DIFF
--- a/crates/svm-rs/src/lib.rs
+++ b/crates/svm-rs/src/lib.rs
@@ -332,7 +332,7 @@ pub fn setup_data_dir() -> Result<PathBuf, SolcVmError> {
     let svm_dir = SVM_DATA_DIR.to_path_buf();
     if !svm_dir.as_path().exists() {
         // Create the directory, continuing if the directory came into existence after the check
-        // for this if statement. This may happen if two copies of SVM run simultaneously.
+        // for this if statement. This may happen if two copies of SVM run simultaneously (e.g CI).
         fs::create_dir_all(svm_dir.clone()).or_else(|err| match err.kind() {
             ErrorKind::AlreadyExists => Ok(()),
             _ => Err(err),


### PR DESCRIPTION
When running Foundry in CI, I encountered an issue where if multiple instances of Foundry were launched at the same time, compiling Solidity source in different directories, one would sometimes fail with an `AlreadyExists` error.

Upon investigating, I noticed that there is indeed a file lock to prevent multiple solc versions from being installed at the same time, but that this file lock does not apply to creating the SVM directory.
This PR adds error hanlding to the `setup_data_dir` function to handle a race condition to create the SVM directory.
