### PR TITLE
feat: `0.8.22` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "build_const",
  "hex",

--- a/crates/svm-builds/Cargo.toml
+++ b/crates/svm-builds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svm-rs-builds"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.65"
 authors = [
@@ -14,7 +14,7 @@ homepage = "https://github.com/roynalnaruto/svm-rs"
 description = "Solidity compiler builds"
 
 [build-dependencies]
-svm = { package = "svm-rs", path = "../svm-rs", version = "0.3.0", default-features = false, features = [
+svm = { package = "svm-rs", path = "../svm-rs", version = "0.3.1", default-features = false, features = [
     "blocking",
     "rustls",
 ] }

--- a/crates/svm-rs/Cargo.toml
+++ b/crates/svm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svm-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Rohit Narurkar <rohit.narurkar@protonmail.com>"]

--- a/crates/svm-rs/src/lib.rs
+++ b/crates/svm-rs/src/lib.rs
@@ -520,7 +520,7 @@ mod tests {
     // ensures we can download the latest native solc for apple silicon
     #[tokio::test(flavor = "multi_thread")]
     async fn can_download_latest_native_apple_silicon() {
-        let latest: Version = "0.8.21".parse().unwrap();
+        let latest: Version = "0.8.22".parse().unwrap();
 
         let artifacts = all_releases(Platform::MacOsAarch64).await.unwrap();
 

--- a/crates/svm-rs/src/lib.rs
+++ b/crates/svm-rs/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
         assert_eq!(
             artifact_url(Platform::LinuxAarch64, &version, artifact).unwrap(),
             Url::parse(&format!(
-                "https://github.com/nikitastupin/solc/raw/53cde9e4624868254a4ac8ca339661e25cb853ef/linux/aarch64/{artifact}"
+                "https://github.com/nikitastupin/solc/raw/3d6c589a6c115d2cc12e9e18941c6f0562c805ee/linux/aarch64/{artifact}"
             ))
             .unwrap(),
         )

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -27,10 +27,10 @@ static OLD_SOLC_RELEASES: Lazy<Releases> = Lazy::new(|| {
 static LINUX_AARCH64_MIN: Lazy<Version> = Lazy::new(|| Version::new(0, 5, 0));
 
 static LINUX_AARCH64_URL_PREFIX: &str =
-    "https://github.com/nikitastupin/solc/raw/53cde9e4624868254a4ac8ca339661e25cb853ef/linux/aarch64";
+    "https://github.com/nikitastupin/solc/raw/3d6c589a6c115d2cc12e9e18941c6f0562c805ee/linux/aarch64";
 
 static LINUX_AARCH64_RELEASES_URL: &str =
-    "https://github.com/nikitastupin/solc/raw/53cde9e4624868254a4ac8ca339661e25cb853ef/linux/aarch64/list.json";
+    "https://github.com/nikitastupin/solc/raw/3d6c589a6c115d2cc12e9e18941c6f0562c805ee/linux/aarch64/list.json";
 
 static MACOS_AARCH64_NATIVE: Lazy<Version> = Lazy::new(|| Version::new(0, 8, 5));
 

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -35,10 +35,10 @@ static LINUX_AARCH64_RELEASES_URL: &str =
 static MACOS_AARCH64_NATIVE: Lazy<Version> = Lazy::new(|| Version::new(0, 8, 5));
 
 static MACOS_AARCH64_URL_PREFIX: &str =
-    "https://github.com/alloy-rs/solc-builds/raw/55ef6c89b8a09c16feee4a424f8a53f822831a61/macosx/aarch64";
+    "https://github.com/alloy-rs/solc-builds/raw/7f117088ae90eefe3724636166f927b3c55cf09c/macosx/aarch64";
 
 static MACOS_AARCH64_RELEASES_URL: &str =
-    "https://github.com/alloy-rs/solc-builds/raw/55ef6c89b8a09c16feee4a424f8a53f822831a61/macosx/aarch64/list.json";
+    "https://github.com/alloy-rs/solc-builds/raw/7f117088ae90eefe3724636166f927b3c55cf09c/macosx/aarch64/list.json";
 
 /// Defines the struct that the JSON-formatted release list can be deserialized into.
 ///


### PR DESCRIPTION
- [x] `macOS` bins updated
- [x] Latest set to 0.8.22
- [x] https://github.com/nikitastupin/solc updated to 0.8.22