### PR TITLE
feat: add support for 0.8.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,12 +494,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -494,6 +523,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -519,8 +559,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -817,6 +859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1029,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "password-hash"
@@ -1285,6 +1360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1451,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1511,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -1453,6 +1565,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [<img alt="docs.rs" src="https://img.shields.io/docsrs/svm-rs/latest?color=66c2a5&label=docs-rs&style=for-the-badge" height="20">](https://docs.rs/svm-rs/latest/svm_lib/)
 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/roynalnaruto/svm-rs/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/roynalnaruto/svm-rs/actions?query=branch%3Amaster)
 
+This crate provides a cross-platform support for managing Solidity compiler versions.
+
 ## Install
 
 From [crates.io](https://crates.io):

--- a/crates/svm-rs/Cargo.toml
+++ b/crates/svm-rs/Cargo.toml
@@ -56,6 +56,7 @@ zip = "0.6"
 rand = "0.8"
 tempfile = "3.10"
 tokio = { version = "1.36", features = ["rt-multi-thread", "macros"] }
+serial_test = "3.0"
 
 [features]
 default = ["rustls", "cli", "solc"]

--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -234,13 +234,9 @@ fn ensure_checksum(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        platform::Platform,
-        releases::{all_releases, artifact_url},
-    };
     use rand::seq::SliceRandom;
 
-    const LATEST: Version = Version::new(0, 8, 24);
+    const LATEST: Version = Version::new(0, 8, 25);
 
     #[tokio::test]
     async fn test_install() {
@@ -307,25 +303,14 @@ mod tests {
         t.await.unwrap().unwrap();
     }
 
-    // ensures we can download the latest native solc for apple silicon
+    // ensures we can download the latest universal solc for apple silicon
     #[tokio::test(flavor = "multi_thread")]
-    async fn can_download_latest_native_apple_silicon() {
-        let artifacts = all_releases(Platform::MacOsAarch64).await.unwrap();
-
-        let artifact = artifacts.releases.get(&LATEST).unwrap();
-        let download_url = artifact_url(
-            Platform::MacOsAarch64,
-            &LATEST,
-            artifact.to_string().as_str(),
-        )
-        .unwrap();
-
-        let expected_checksum = artifacts.get_checksum(&LATEST).unwrap();
-
-        let resp = reqwest::get(download_url).await.unwrap();
-        assert!(resp.status().is_success());
-        let binbytes = resp.bytes().await.unwrap();
-        ensure_checksum(&binbytes, &LATEST, &expected_checksum).unwrap();
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    async fn can_install_latest_native_apple_silicon() {
+        let solc = install(&LATEST).await.unwrap();
+        let output = Command::new(solc).arg("--version").output().unwrap();
+        let version = String::from_utf8_lossy(&output.stdout);
+        assert!(version.contains("0.8.25"), "{}", version);
     }
 
     // ensures we can download the latest native solc for linux aarch64

--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -236,6 +236,7 @@ mod tests {
     use super::*;
     use rand::seq::SliceRandom;
 
+    #[allow(unused)]
     const LATEST: Version = Version::new(0, 8, 25);
 
     #[tokio::test]

--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -240,6 +240,7 @@ mod tests {
     const LATEST: Version = Version::new(0, 8, 25);
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_install() {
         let versions = all_releases(platform())
             .await
@@ -252,6 +253,7 @@ mod tests {
     }
 
     #[cfg(feature = "blocking")]
+    #[serial_test::serial]
     #[test]
     fn blocking_test_install() {
         let versions = crate::releases::blocking_all_releases(platform::platform())
@@ -262,6 +264,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_version() {
         let version = "0.8.10".parse().unwrap();
         install(&version).await.unwrap();
@@ -273,6 +276,7 @@ mod tests {
     }
 
     #[cfg(feature = "blocking")]
+    #[serial_test::serial]
     #[test]
     fn blocking_test_version() {
         let version = "0.8.10".parse().unwrap();

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -196,11 +196,11 @@ pub async fn all_releases(platform: Platform) -> Result<Releases, SvmError> {
             .json::<Releases>()
             .await?;
             releases.builds.retain(|b| {
-                b.version.lt(&MACOS_AARCH64_NATIVE) || b.version.gt(&UNIVERSAL_MACOS_BINARIES)
+                b.version < MACOS_AARCH64_NATIVE || b.version > UNIVERSAL_MACOS_BINARIES
             });
             releases
                 .releases
-                .retain(|v, _| v.lt(&MACOS_AARCH64_NATIVE) || v.gt(&UNIVERSAL_MACOS_BINARIES));
+                .retain(|v, _| *v < MACOS_AARCH64_NATIVE || *v > UNIVERSAL_MACOS_BINARIES);
 
             releases.builds.extend_from_slice(&native.builds);
             releases.releases.append(&mut native.releases);
@@ -236,8 +236,8 @@ pub(crate) fn artifact_url(
     artifact: &str,
 ) -> Result<Url, SvmError> {
     if platform == Platform::LinuxAmd64
-        && version.le(&OLD_VERSION_MAX)
-        && version.ge(&OLD_VERSION_MIN)
+        && *version <= OLD_VERSION_MAX
+        && *version >= OLD_VERSION_MIN
     {
         return Ok(Url::parse(&format!(
             "{OLD_SOLC_RELEASES_DOWNLOAD_PREFIX}/{artifact}"
@@ -245,7 +245,7 @@ pub(crate) fn artifact_url(
     }
 
     if platform == Platform::LinuxAarch64 {
-        if version.ge(&LINUX_AARCH64_MIN) {
+        if *version >= LINUX_AARCH64_MIN {
             return Ok(Url::parse(&format!(
                 "{LINUX_AARCH64_URL_PREFIX}/{artifact}"
             ))?);
@@ -257,7 +257,7 @@ pub(crate) fn artifact_url(
         }
     }
 
-    if platform == Platform::MacOsAmd64 && version.lt(&OLD_VERSION_MIN) {
+    if platform == Platform::MacOsAmd64 && *version < OLD_VERSION_MIN {
         return Err(SvmError::UnsupportedVersion(
             version.to_string(),
             platform.to_string(),
@@ -265,7 +265,7 @@ pub(crate) fn artifact_url(
     }
 
     if platform == Platform::MacOsAarch64 {
-        if version.ge(&MACOS_AARCH64_NATIVE) && version.le(&UNIVERSAL_MACOS_BINARIES) {
+        if *version >= MACOS_AARCH64_NATIVE && *version <= UNIVERSAL_MACOS_BINARIES {
             // fetch natively build solc binaries from `https://github.com/alloy-rs/solc-builds`
             return Ok(Url::parse(&format!(
                 "{MACOS_AARCH64_URL_PREFIX}/{artifact}"

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -8,8 +8,13 @@ use url::Url;
 
 // Updating new releases:
 // 1. Update `https://github.com/nikitastupin/solc` commit for `linux/aarch64`
-// 2. Update `https://github.com/alloy-rs/solc-builds` commit for `macosx/aarch64`
+// 2. Update LATEST for tests
 
+/// Base URL for all Solc releases
+/// `"SOLC_RELEASES_URL}/{platform}/list.json"`:
+/// `https://binaries.soliditylang.org/linux-amd64/list.json`
+/// `https://binaries.soliditylang.org/windows-amd64/list.json`
+/// `https://binaries.soliditylang.org/macosx-amd64/list.json`
 const SOLC_RELEASES_URL: &str = "https://binaries.soliditylang.org";
 
 const OLD_SOLC_RELEASES_DOWNLOAD_PREFIX: &str =
@@ -27,12 +32,15 @@ static OLD_SOLC_RELEASES: Lazy<Releases> = Lazy::new(|| {
 const LINUX_AARCH64_MIN: Version = Version::new(0, 5, 0);
 
 static LINUX_AARCH64_URL_PREFIX: &str =
-    "https://github.com/nikitastupin/solc/raw/7687d6ce15553292adbb3e6c565eafea6e0caf85/linux/aarch64";
+    "https://github.com/nikitastupin/solc/raw/fd781c58fe3abb978749bb3184405d1fe7c4cd26/linux/aarch64";
 
 static LINUX_AARCH64_RELEASES_URL: &str =
-    "https://github.com/nikitastupin/solc/raw/7687d6ce15553292adbb3e6c565eafea6e0caf85/linux/aarch64/list.json";
+    "https://github.com/nikitastupin/solc/raw/fd781c58fe3abb978749bb3184405d1fe7c4cd26/linux/aarch64/list.json";
 
+// NOTE: Since version 0.8.24, universal macosx releases are available: https://binaries.soliditylang.org/macosx-amd64/list.json
 const MACOS_AARCH64_NATIVE: Version = Version::new(0, 8, 5);
+
+const UNIVERSAL_MACOS_BINARIES: Version = Version::new(0, 8, 24);
 
 static MACOS_AARCH64_URL_PREFIX: &str =
     "https://github.com/alloy-rs/solc-builds/raw/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64";
@@ -133,6 +141,8 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SvmError> {
             //
             // 2. For version <= 0.8.4 we fetch releases from https://binaries.soliditylang.org and
             // require Rosetta support.
+            //
+            // Note: Since 0.8.24 universal macosx releases are available
             let mut native =
                 reqwest::blocking::get(MACOS_AARCH64_RELEASES_URL)?.json::<Releases>()?;
             let mut releases = reqwest::blocking::get(format!(
@@ -145,6 +155,7 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SvmError> {
                 .builds
                 .retain(|b| b.version.lt(&MACOS_AARCH64_NATIVE));
             releases.builds.extend_from_slice(&native.builds);
+
             releases.releases.append(&mut native.releases);
             Ok(releases)
         }
@@ -184,10 +195,12 @@ pub async fn all_releases(platform: Platform) -> Result<Releases, SvmError> {
             .await?
             .json::<Releases>()
             .await?;
+            releases.builds.retain(|b| {
+                b.version.lt(&MACOS_AARCH64_NATIVE) || b.version.gt(&UNIVERSAL_MACOS_BINARIES)
+            });
             releases
-                .builds
-                .retain(|b| b.version.lt(&MACOS_AARCH64_NATIVE));
-            releases.releases.retain(|v, _| v.lt(&MACOS_AARCH64_NATIVE));
+                .releases
+                .retain(|v, _| v.lt(&MACOS_AARCH64_NATIVE) || v.gt(&UNIVERSAL_MACOS_BINARIES));
 
             releases.builds.extend_from_slice(&native.builds);
             releases.releases.append(&mut native.releases);
@@ -252,11 +265,13 @@ pub(crate) fn artifact_url(
     }
 
     if platform == Platform::MacOsAarch64 {
-        if version.ge(&MACOS_AARCH64_NATIVE) {
+        if version.ge(&MACOS_AARCH64_NATIVE) && version.le(&UNIVERSAL_MACOS_BINARIES) {
+            // fetch natively build solc binaries from `https://github.com/alloy-rs/solc-builds`
             return Ok(Url::parse(&format!(
                 "{MACOS_AARCH64_URL_PREFIX}/{artifact}"
             ))?);
         } else {
+            // if version is older or universal macos binaries are available, fetch from `https://binaries.soliditylang.org`
             return Ok(Url::parse(&format!(
                 "{}/{}/{}",
                 SOLC_RELEASES_URL,
@@ -282,7 +297,7 @@ mod tests {
         assert_eq!(
             artifact_url(Platform::LinuxAarch64, &version, artifact).unwrap(),
             Url::parse(&format!(
-                "https://github.com/nikitastupin/solc/raw/7687d6ce15553292adbb3e6c565eafea6e0caf85/linux/aarch64/{artifact}"
+                "https://github.com/nikitastupin/solc/raw/fd781c58fe3abb978749bb3184405d1fe7c4cd26/linux/aarch64/{artifact}"
             ))
             .unwrap(),
         )


### PR DESCRIPTION
solc now ships universal macos binaries, so we no longer have to build them for https://github.com/alloy-rs/solc-builds