### PR TITLE
chore: release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "build_const",
  "const-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/svm-builds", "crates/svm-rs"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.70"
 authors = [
@@ -17,7 +17,7 @@ repository = "https://github.com/alloy-rs/svm-rs"
 homepage = "https://github.com/alloy-rs/svm-rs"
 
 [workspace.dependencies]
-svm = { package = "svm-rs", version = "0.3.6", path = "crates/svm-rs", default-features = false }
+svm = { package = "svm-rs", version = "0.4.0", path = "crates/svm-rs", default-features = false }
 
 hex = { package = "const-hex", version = "1.10" }
 semver = "1"


### PR DESCRIPTION
breaking changes on last release