### PR TITLE
fix: filter for universal macos

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -278,6 +278,19 @@ mod tests {
     #[cfg(feature = "blocking")]
     #[serial_test::serial]
     #[test]
+    fn blocking_test_latest() {
+        blocking_install(&LATEST).unwrap();
+        let solc_path = version_binary(LATEST.to_string().as_str());
+        let output = Command::new(solc_path).arg("--version").output().unwrap();
+
+        assert!(String::from_utf8_lossy(&output.stdout)
+            .as_ref()
+            .contains(&LATEST.to_string()));
+    }
+
+    #[cfg(feature = "blocking")]
+    #[serial_test::serial]
+    #[test]
     fn blocking_test_version() {
         let version = "0.8.10".parse().unwrap();
         blocking_install(&version).unwrap();

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -151,9 +151,12 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SvmError> {
                 Platform::MacOsAmd64,
             ))?
             .json::<Releases>()?;
+            releases.builds.retain(|b| {
+                b.version < MACOS_AARCH64_NATIVE || b.version > UNIVERSAL_MACOS_BINARIES
+            });
             releases
-                .builds
-                .retain(|b| b.version.lt(&MACOS_AARCH64_NATIVE));
+                .releases
+                .retain(|v, _| *v < MACOS_AARCH64_NATIVE || *v > UNIVERSAL_MACOS_BINARIES);
             releases.builds.extend_from_slice(&native.builds);
 
             releases.releases.append(&mut native.releases);


### PR DESCRIPTION
add missing checks for macos aarch64