### PR TITLE
perf: use `raw.githubusercontent.com` direct link to avoid 302 redirects

### DIFF
--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -32,10 +32,10 @@ static OLD_SOLC_RELEASES: Lazy<Releases> = Lazy::new(|| {
 const LINUX_AARCH64_MIN: Version = Version::new(0, 5, 0);
 
 static LINUX_AARCH64_URL_PREFIX: &str =
-    "https://github.com/nikitastupin/solc/raw/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64";
+    "https://raw.githubusercontent.com/nikitastupin/solc/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64";
 
 static LINUX_AARCH64_RELEASES_URL: &str =
-    "https://github.com/nikitastupin/solc/raw/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64/list.json";
+    "https://raw.githubusercontent.com/nikitastupin/solc/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64/list.json";
 
 // NOTE: Since version 0.8.24, universal macosx releases are available: https://binaries.soliditylang.org/macosx-amd64/list.json
 const MACOS_AARCH64_NATIVE: Version = Version::new(0, 8, 5);
@@ -43,10 +43,10 @@ const MACOS_AARCH64_NATIVE: Version = Version::new(0, 8, 5);
 const UNIVERSAL_MACOS_BINARIES: Version = Version::new(0, 8, 24);
 
 static MACOS_AARCH64_URL_PREFIX: &str =
-    "https://github.com/alloy-rs/solc-builds/raw/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64";
+    "https://raw.githubusercontent.com/alloy-rs/solc-builds/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64";
 
 static MACOS_AARCH64_RELEASES_URL: &str =
-    "https://github.com/alloy-rs/solc-builds/raw/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64/list.json";
+    "https://raw.githubusercontent.com/alloy-rs/solc-builds/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64/list.json";
 
 /// Defines the struct that the JSON-formatted release list can be deserialized into.
 ///
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(
             artifact_url(Platform::LinuxAarch64, &version, artifact).unwrap(),
             Url::parse(&format!(
-                "https://github.com/nikitastupin/solc/raw/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64/{artifact}"
+                "https://raw.githubusercontent.com/nikitastupin/solc/57211f3e182ce7c2a7c0fdead02656d404d9b37a/linux/aarch64/{artifact}"
             ))
             .unwrap(),
         )


### PR DESCRIPTION
Small performance optimization to avoid `302` redirect, requested in https://github.com/foundry-rs/foundry/issues/7440