### PR TITLE
feat: increase `solc` download timeout window to 10 minutes from 2 minutes

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -15,8 +15,8 @@ use std::{
 #[cfg(target_family = "unix")]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
-/// The timeout to use for requests to the source
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+/// The timeout to use for requests to the source (10 minutes).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Version beyond which solc binaries are not fully static, hence need to be patched for NixOS.
 const NIXOS_MIN_PATCH_VERSION: Version = Version::new(0, 7, 6);


### PR DESCRIPTION
From https://github.com/foundry-rs/foundry/issues/8507:

Downloading the solc compiler is timing out too quickly. This makes it impossible to use forge with slow internet speeds.

```
$ forge build -- --vvvv
Error: 
error decoding response body

Context:
- Error #0: request or response body error
- Error #1: operation timed out
```

### Cause

- The solc binary size for mac has increased from 37MB to 79MB since v0.8.23.
- The timeout for forge to download the binary is less than 3 minutes.
- On a slow internet connection, there is not enough time for the download to complete before timing out.

### Solution

- Increase the timeout limit for downloads to 10 minutes

Closes: https://github.com/foundry-rs/foundry/issues/8507