### PR TITLE
Eliminate "text file busy" errors

### DIFF
--- a/crates/svm-rs/Cargo.toml
+++ b/crates/svm-rs/Cargo.toml
@@ -35,6 +35,7 @@ semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2 = "0.10"
+tempfile = "3.10"
 thiserror = "1.0"
 url = "2.5"
 

--- a/crates/svm-rs/src/error.rs
+++ b/crates/svm-rs/src/error.rs
@@ -26,6 +26,8 @@ pub enum SvmError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]
+    PersistError(#[from] tempfile::PathPersistError),
+    #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]
     SemverError(#[from] semver::Error),


### PR DESCRIPTION
While running some tests involving Foundry, I have encountered "text file busy" errors, like described in #16.

This PR is currently organized as two commits:
- Add `can_install_while_solc_is_running` test - intentionally fails with "text file busy"
- Eliminate "test file busy" errors - installs solc to a temporary file and then renames it, so that the previous test passes

Nits are welcome.

EDIT: ~I'll be happy to fix the typo in the commit message, once you've had a chance to review.~ Fixed.