### PR TITLE
Bump fs4 version to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6fcfb3c0c1d71612528825042261419d5dade9678c39a781e05b63677d9b32"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",

--- a/crates/svm-rs/Cargo.toml
+++ b/crates/svm-rs/Cargo.toml
@@ -34,7 +34,7 @@ vergen = { version = "8", optional = true, features = [
 ] }
 
 [dependencies]
-fs4 = "0.10"
+fs4 = "0.12"
 hex.workspace = true
 dirs = "5.0"
 reqwest = { workspace = true, default-features = false, features = ["json"] }


### PR DESCRIPTION
fs4 version 0.10 was yanked from crates.io thus `cargo install` is broken now.
This PR bumps fs4 version to the latest one fixing the installation issue