### PR TITLE
feat: add android-aarch64 support

### DIFF
--- a/crates/svm-builds/build.rs
+++ b/crates/svm-builds/build.rs
@@ -14,6 +14,7 @@ use svm::Releases;
 /// - "macosx-amd64"
 /// - "macosx-aarch64"
 /// - "windows-amd64"
+/// - "android-aarch64"
 pub const SVM_TARGET_PLATFORM: &str = "SVM_TARGET_PLATFORM";
 
 /// The path to the releases JSON file, that was pre-fetched manually.

--- a/crates/svm-rs/src/platform.rs
+++ b/crates/svm-rs/src/platform.rs
@@ -10,6 +10,7 @@ pub enum Platform {
     MacOsAmd64,
     MacOsAarch64,
     WindowsAmd64,
+    AndroidAarch64,
     Unsupported,
 }
 
@@ -21,6 +22,7 @@ impl fmt::Display for Platform {
             Self::MacOsAmd64 => "macosx-amd64",
             Self::MacOsAarch64 => "macosx-aarch64",
             Self::WindowsAmd64 => "windows-amd64",
+            Self::AndroidAarch64 => "android-aarch64",
             Self::Unsupported => "Unsupported-platform",
         };
         f.write_str(s)
@@ -37,6 +39,7 @@ impl FromStr for Platform {
             "macosx-amd64" => Ok(Self::MacOsAmd64),
             "macosx-aarch64" => Ok(Self::MacOsAarch64),
             "windows-amd64" => Ok(Self::WindowsAmd64),
+            "android-aarch64" => Ok(Self::AndroidAarch64),
             s => Err(format!("unsupported platform {s}")),
         }
     }
@@ -57,6 +60,7 @@ pub fn platform() -> Platform {
         ("macos", "x86_64") => Platform::MacOsAmd64,
         ("macos", "aarch64") => Platform::MacOsAarch64,
         ("windows", "x86_64") => Platform::WindowsAmd64,
+        ("android", "aarch64") => Platform::AndroidAarch64,
         _ => Platform::Unsupported,
     }
 }
@@ -93,5 +97,11 @@ mod tests {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     fn get_platform() {
         assert_eq!(platform(), Platform::WindowsAmd64);
+    }
+
+    #[test]
+    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    fn get_platform() {
+        assert_eq!(platform(), Platform::AndroidAarch64);
     }
 }

--- a/crates/svm-rs/src/releases.rs
+++ b/crates/svm-rs/src/releases.rs
@@ -47,6 +47,14 @@ static MACOS_AARCH64_URL_PREFIX: &str =
 static MACOS_AARCH64_RELEASES_URL: &str =
     "https://raw.githubusercontent.com/alloy-rs/solc-builds/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64/list.json";
 
+const ANDROID_AARCH64_MIN: Version = Version::new(0, 8, 24);
+
+static ANDROID_AARCH64_URL_PREFIX: &str =
+    "https://raw.githubusercontent.com/alloy-rs/solc-builds/5a404a4839fdde4a6093aee1b3d75a8dce38f40f/android/aarch64";
+
+static ANDROID_AARCH64_RELEASES_URL: &str =
+    "https://raw.githubusercontent.com/alloy-rs/solc-builds/5a404a4839fdde4a6093aee1b3d75a8dce38f40f/android/aarch64/list.json";
+
 /// Defines the struct that the JSON-formatted release list can be deserialized into.
 ///
 /// Both the key and value are deserialized into [`semver::Version`].
@@ -161,6 +169,9 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SvmError> {
             releases.releases.append(&mut native.releases);
             Ok(releases)
         }
+        Platform::AndroidAarch64 => {
+            Ok(reqwest::blocking::get(ANDROID_AARCH64_RELEASES_URL)?.json::<Releases>()?)
+        }
         _ => {
             let releases =
                 reqwest::blocking::get(format!("{SOLC_RELEASES_URL}/{platform}/list.json"))?
@@ -208,6 +219,10 @@ pub async fn all_releases(platform: Platform) -> Result<Releases, SvmError> {
             releases.releases.append(&mut native.releases);
             Ok(releases)
         }
+        Platform::AndroidAarch64 => Ok(get(ANDROID_AARCH64_RELEASES_URL)
+            .await?
+            .json::<Releases>()
+            .await?),
         _ => {
             let releases = get(format!("{SOLC_RELEASES_URL}/{platform}/list.json"))
                 .await?
@@ -280,6 +295,19 @@ pub(crate) fn artifact_url(
                 Platform::MacOsAmd64,
                 artifact,
             ))?);
+        }
+    }
+
+    if platform == Platform::AndroidAarch64 {
+        if version.ge(&ANDROID_AARCH64_MIN) {
+            return Ok(Url::parse(&format!(
+                "{ANDROID_AARCH64_URL_PREFIX}/{artifact}"
+            ))?);
+        } else {
+            return Err(SvmError::UnsupportedVersion(
+                version.to_string(),
+                platform.to_string(),
+            ));
         }
     }
 


### PR DESCRIPTION
Should have sent this in long ago right after https://github.com/alloy-rs/solc-builds/pull/12 but somehow forgot to.

This PR adds Android aarch64 support so that you can finally use Foundry on Android through [Termux](https://termux.dev/).