### PR TITLE
feat: add aliases `ls`, `i`, and `rm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Usage: svm <COMMAND>
 
 Commands:
   help     Print this message or the help of the given subcommand(s)
-  install  Install Solc versions
-  list     List all Solc versions
-  remove   Remove a Solc version, or "all" to remove all versions
+  install  Install Solc versions [aliases: i]
+  list     List all Solc versions [aliases: ls]
+  remove   Remove a Solc version, or "all" to remove all versions [aliases: rm]
   use      Set a Solc version as the global default
+  which    Display which binary will be run for a given version
 
 Options:
   -h, --help     Print help

--- a/crates/svm-rs/src/bin/svm-bin/main.rs
+++ b/crates/svm-rs/src/bin/svm-bin/main.rs
@@ -26,10 +26,13 @@ mod which;
     next_display_order = None,
 )]
 enum Svm {
+    #[command(visible_alias = "ls")]
     List(list::ListCmd),
+    #[command(visible_alias = "i")]
     Install(install::InstallCmd),
     Use(r#use::UseCmd),
     Which(which::WhichCmd),
+    #[command(visible_alias = "rm")]
     Remove(remove::RemoveCmd),
 }
 


### PR DESCRIPTION
This PR adds the following subcommand aliases:
- `ls` for `list`
- `i` for `install`
- `rm` for `remove`

It's a small change, but I think it will improve usability (especially `ls`, which is very common).

Here is a comparison with other version managers, for reference:

`svm-rs` | [`solc-select`](https://github.com/crytic/solc-select) | [`fnm`](https://github.com/Schniz/fnm) | [`nvm`](https://github.com/nvm-sh/nvm/) | [`uv`](https://github.com/astral-sh/uv) (using `uv python`)
--- | --- | --- | --- | ---
`list` | N/A (uses `install` without an argument to list all versions) | `list`, `ls` | `list`, `ls` | `list`, `ls`
`install` | `install` | `install`, `i` | `install`, `i` | `install`
`remove` | N/A | `uninstall`, `uni` | `uninstall` | `uninstall`

While updating the `README` to add the aliases, I noticed the `which` subcommand was missing, so I went ahead and updated that as well.