### PR TITLE
chore: improve UnknownVersion error message

### DIFF
--- a/crates/svm-rs/src/error.rs
+++ b/crates/svm-rs/src/error.rs
@@ -1,4 +1,5 @@
 use reqwest::StatusCode;
+use semver::Version;
 use thiserror::Error;
 use url::Url;
 
@@ -7,8 +8,8 @@ use url::Url;
 pub enum SvmError {
     #[error("SVM global version not set")]
     GlobalVersionNotSet,
-    #[error("Unknown version provided")]
-    UnknownVersion,
+    #[error("version not found in artifacts for this platform: {0}")]
+    UnknownVersion(Version),
     #[error("Unsupported version {0} for platform {1}")]
     UnsupportedVersion(String, String),
     #[error("Version {0} not installed")]

--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -34,7 +34,7 @@ pub fn blocking_install(version: &Version) -> Result<PathBuf, SvmError> {
     let artifacts = crate::blocking_all_releases(platform::platform())?;
     let artifact = artifacts
         .get_artifact(version)
-        .ok_or(SvmError::UnknownVersion)?;
+        .ok_or_else(|| SvmError::UnknownVersion(version.clone()))?;
     let download_url = artifact_url(platform::platform(), version, artifact.to_string().as_str())?;
 
     let expected_checksum = artifacts
@@ -79,7 +79,7 @@ pub async fn install(version: &Version) -> Result<PathBuf, SvmError> {
     let artifact = artifacts
         .releases
         .get(version)
-        .ok_or(SvmError::UnknownVersion)?;
+        .ok_or_else(|| SvmError::UnknownVersion(version.clone()))?;
     let download_url = artifact_url(platform::platform(), version, artifact.to_string().as_str())?;
 
     let expected_checksum = artifacts


### PR DESCRIPTION
This can happen for arm linux which is missing 0.4.* artifacts. The current error message is very cryptic, improve it.