### PR TITLE
feat: support solc prereleases

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -77,8 +77,7 @@ pub async fn install(version: &Version) -> Result<PathBuf, SvmError> {
 
     let artifacts = all_releases(platform::platform()).await?;
     let artifact = artifacts
-        .releases
-        .get(version)
+        .get_artifact(version)
         .ok_or_else(|| SvmError::UnknownVersion(version.clone()))?;
     let download_url = artifact_url(platform::platform(), version, artifact.to_string().as_str())?;
 


### PR DESCRIPTION
- consolidate logic to lookup artifacts in build info in case we cannot match the artifact in releases and we're dealing with a prerelease. Needed because of the inconsistency of how prereleases are listed on binaries.soliditylang.org:
  - prereleases on binaries.soliditylang.org are not listed under releases but only under builds (see https://binaries.soliditylang.org/linux-amd64/list.json) e.g.
  ```json
  {
    "builds": [
  ...
      {
        "path": "solc-linux-amd64-v0.8.30+commit.73712a01",
        "version": "0.8.30",
        "build": "commit.73712a01",
        "longVersion": "0.8.30+commit.73712a01",
  ...
      },
      {
        "path": "solc-linux-amd64-v0.8.31-pre.1+commit.b59566f6",
        "version": "0.8.31",
        "prerelease": "pre.1",
        "build": "commit.b59566f6",
        "longVersion": "0.8.31-pre.1+commit.b59566f6",
  ...
      }
    ],
    "releases": {
      "0.8.30": "solc-linux-amd64-v0.8.30+commit.73712a01",
  ...
    },
    "latestRelease": "0.8.30"
  }
  ```
  - prereleases for linux/aarch64 are listed under releases (see https://raw.githubusercontent.com/nikitastupin/solc/2287d4326237172acf91ce42fd7ec18a67b7f512/linux/aarch64/list.json) e.g.
  ```json
  {
    "builds": [
  ...
      {
        "version": "0.8.30",
        "sha256": "54f48274e5ec8a58b378f07c226fa1e25801526b6b0d16129f3a14a18efe72cd"
      },
      {
        "version": "0.8.31-pre.1",
        "sha256": "70bd29bdc271654c58e2cbd62f2b55d2b97db49ed97f42775287f8c43e285bd5"
      }
    ],
    "releases": {
  ...
      "0.8.30": "solc-v0.8.30",
      "0.8.31-pre.1": "solc-v0.8.31-pre.1"
    }
  }
  ```
