### PR TITLE
chore: solc 0.8.35

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -304,7 +304,7 @@ mod tests {
     use rand::seq::IndexedRandom;
 
     #[allow(unused)]
-    const LATEST: Version = Version::new(0, 8, 34);
+    const LATEST: Version = Version::new(0, 8, 35);
 
     #[tokio::test]
     #[serial_test::serial]


### PR DESCRIPTION
Adds support for solc 0.8.35.

Release: https://github.com/argotorg/solidity/releases/tag/v0.8.35

Prompted by: @zerosnacks 