### PR TITLE
chore: group weekly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: 09:00
+      timezone: UTC
     cooldown:
       default-days: 7
     groups:
-      actions-weekly:
-        applies-to: "version-updates"
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-
-  - package-ecosystem: "cargo"
-    directory: "/"
+      ci-weekly:
+        patterns:
+          - '*'
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: 09:00
+      timezone: UTC
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
     groups:
       cargo-weekly:
-        applies-to: "version-updates"
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- run all Dependabot ecosystems on a weekly schedule
- group dependency updates with a catch-all pattern
- group GitHub Actions/CI updates as `ci-weekly`

## Testing
- validated `.github/dependabot.yml` parses as YAML and every update entry is weekly with a dependency group