### PR TITLE
ci: set clippy tool input explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: nightly
+          tool: clippy
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:


### PR DESCRIPTION
## Summary
- set the explicit `tool: clippy` input for the clippy rust-toolchain step
- keep `toolchain: nightly` and `components: clippy` unchanged

## Testing
- Parsed workflow YAML with PyYAML

Prompted by: @DaniPopes