### PR TITLE
chore: solc 0.8.36

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -304,7 +304,7 @@ mod tests {
     use rand::seq::IndexedRandom;
 
     #[allow(unused)]
-    const LATEST: Version = Version::new(0, 8, 35);
+    const LATEST: Version = Version::new(0, 8, 36);
 
     #[tokio::test]
     #[serial_test::serial]


### PR DESCRIPTION
Adds support for Solidity 0.8.36 by updating the latest-version install test constant.

The embedded release data in `svm-rs-builds` is generated from the official Solidity binary manifests at build/publish time, and those manifests now expose `0.8.36` as `latestRelease`.

Release links:
- https://www.soliditylang.org/blog/2026/07/09/solidity-0.8.36-release-announcement/
- https://github.com/argotorg/solidity/releases/tag/v0.8.36