### PR TITLE
chore: solc 0.8.37

### DIFF
--- a/crates/svm-rs/src/install.rs
+++ b/crates/svm-rs/src/install.rs
@@ -488,7 +488,7 @@ mod tests {
     use rand::seq::IndexedRandom;
 
     #[allow(unused)]
-    const LATEST: Version = Version::new(0, 8, 36);
+    const LATEST: Version = Version::new(0, 8, 37);
 
     #[tokio::test]
     async fn test_install() {


### PR DESCRIPTION
Updates the latest-version install test constant to Solidity 0.8.37, following [#224](https://github.com/alloy-rs/svm-rs/pull/224).

The embedded release data in `svm-rs-builds` is generated from upstream release manifests at build time. The official Linux amd64, macOS amd64, and Windows amd64 manifests now list `0.8.37` as `latestRelease`.

Release: https://github.com/argotorg/solidity/releases/tag/v0.8.37

Validation:
- `cargo +stable test -p svm-rs --features blocking latest -- --nocapture` passed on Linux amd64, including installation and execution of solc 0.8.37.
- `cargo +nightly fmt --all --check` passed.
- `git diff --check` passed.

Prompted by: @mattsse
